### PR TITLE
Show placeholder instead of broken image

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || 'placeholder.png'}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image || 'placeholder.png'}
+        src={item.image || "placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Show placeholder instead of empty image. Fix for #2 

<img width="508" alt="CleanShot 2022-10-11 at 11 21 13@2x" src="https://user-images.githubusercontent.com/1262859/195037426-248e8e62-ed57-4a10-b062-ed6051cc3aa8.png">
